### PR TITLE
Adding ground truth evaluation using AgentCore Eval (module 05-04)

### DIFF
--- a/05-framework-specific-evaluations/05-04-AgentCore-Runtime-Evals/05-04-AgentCore-Evals-Ground-Truth.ipynb
+++ b/05-framework-specific-evaluations/05-04-AgentCore-Runtime-Evals/05-04-AgentCore-Evals-Ground-Truth.ipynb
@@ -1,0 +1,1671 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "intro-md",
+   "metadata": {},
+   "source": [
+    "# City Search Agent — Ground Truth Evaluations\n",
+    "\n",
+    "This notebook demonstrates evaluation of an agentic application with ground truth using Amazon Bedrock AgentCore Evaluations:\n",
+    "\n",
+    "| Interface | When to use |\n",
+    "|---|---|\n",
+    "| **EvaluationClient** | You already have agent sessions in CloudWatch. Evaluate specific sessions against reference inputs. |\n",
+    "| **OnDemandEvaluationDatasetRunner** | You have a test dataset. You want to invoke the agent for every scenario and evaluate the results. |\n",
+    "\n",
+    "### The City Search Agent\n",
+    "\n",
+    "We'll deploy the same **City Search Agent** used throughout this workshop — a Strands agent that helps users find:\n",
+    "- Population data for US cities\n",
+    "- Land area (in square miles) for US cities\n",
+    "\n",
+    "The agent uses a `web_search` tool (DuckDuckGo) to look up current information, then returns structured answers with `<pop>` and `<area>` XML tags for programmatic parsing.\n",
+    "\n",
+    "### What You'll Learn\n",
+    "- How to use `EvaluationClient` to evaluate existing agent sessions logged in Amazon CloudWatch with ground-truth references\n",
+    "- How to use `OnDemandEvaluationDatasetRunner` to run automated dataset evaluations\n",
+    "- How to create **custom LLM-as-a-Judge evaluators** with ground truth placeholders\n",
+    "- How to interpret evaluation results across built-in evaluators (Correctness, GoalSuccessRate, Trajectory)\n",
+    "\n",
+    "### Tutorial Details\n",
+    "\n",
+    "| Information | Details |\n",
+    "|---|---|\n",
+    "| Agent framework | Strands Agents |\n",
+    "| Runtime | Amazon Bedrock AgentCore Runtime |\n",
+    "| Evaluation SDK | `bedrock-agentcore` |\n",
+    "| AWS services | AgentCore Runtime, AgentCore Evaluations, CloudWatch Logs |\n",
+    "\n",
+    "### Prerequisites\n",
+    "- Python 3.10+\n",
+    "- AWS credentials with permissions for AgentCore, Lambda, CloudWatch, ECR, IAM\n",
+    "- Docker running locally (for agent container image build)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "install-md",
+   "metadata": {},
+   "source": [
+    "## Step 1: Install Dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "install",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -r requirements.txt -q"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "setup-md",
+   "metadata": {},
+   "source": [
+    "## Step 2: Configuration\n",
+    "\n",
+    "Import libraries and configure your AWS session."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "setup",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Region  : us-west-2\n"
+     ]
+    }
+   ],
+   "source": [
+    "import boto3\n",
+    "import json\n",
+    "import time\n",
+    "import uuid\n",
+    "from datetime import timedelta\n",
+    "from boto3.session import Session\n",
+    "from IPython.display import display, Markdown\n",
+    "\n",
+    "boto_session = Session()\n",
+    "REGION = boto_session.region_name\n",
+    "\n",
+    "print(f\"Region  : {REGION}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "deploy-md",
+   "metadata": {},
+   "source": [
+    "## Step 3: Deploy the City Search Agent\n",
+    "\n",
+    "We deploy the same City Search Agent used in module 03 (Agentic Metrics) and module 05-02 (AgentCore) to **AgentCore Runtime**.\n",
+    "\n",
+    "The agent uses:\n",
+    "- **web_search tool**: Queries DuckDuckGo for current city population and area data\n",
+    "- **Amazon Nova Micro**: Optimized for low latency and cost\n",
+    "- **XML output format**: `<pop>` and `<area>` tags for programmatic parsing\n",
+    "\n",
+    "The deployment steps are:\n",
+    "1. **Write agent file** — create `citysearch.py` with the BedrockAgentCoreApp entrypoint\n",
+    "2. **Configure** — set up ECR, IAM roles, and agent configuration\n",
+    "3. **Launch** — build container via CodeBuild and deploy to AgentCore Runtime"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "write-agent",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Overwriting citysearch.py\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%writefile citysearch.py\n",
+    "from botocore.config import Config\n",
+    "from ddgs import DDGS\n",
+    "from strands import Agent, tool\n",
+    "from strands.models import BedrockModel\n",
+    "\n",
+    "from bedrock_agentcore.runtime import BedrockAgentCoreApp\n",
+    "from boto3.session import Session\n",
+    "\n",
+    "boto_session = Session()\n",
+    "region = boto_session.region_name\n",
+    "\n",
+    "# Custom config for Bedrock — short timeouts, no retries\n",
+    "quick_config = Config(\n",
+    "    connect_timeout=5,\n",
+    "    read_timeout=20,\n",
+    "    retries={\"max_attempts\": 0}\n",
+    ")\n",
+    "\n",
+    "\n",
+    "@tool\n",
+    "def web_search(topic: str) -> str:\n",
+    "    \"\"\"Search DuckDuckGo for a given topic.\n",
+    "    Return a string listing the top 5 results including the url, title, and description of each result.\n",
+    "    \"\"\"\n",
+    "    try:\n",
+    "        results = DDGS(timeout=5).text(topic, region=region, max_results=5)\n",
+    "        return results if results else \"No results found.\"\n",
+    "    except Exception as e:\n",
+    "        return f\"Search error: {str(e)}\"\n",
+    "\n",
+    "\n",
+    "SYSTEM_PROMPT = \"\"\"You are a helpful city information assistant.\n",
+    "\n",
+    "You help users find population and land area data for US cities.\n",
+    "Always use the web_search tool to look up current data — do not guess.\n",
+    "Be concise, professional, and friendly.\n",
+    "\n",
+    "After your response, also include your answer in 'pop' and 'area' XML tags\n",
+    "for programmatic processing.\n",
+    "The values in the XML tags should only be numbers, no words or commas.\"\"\"\n",
+    "\n",
+    "chatbot_model = BedrockModel(\n",
+    "    model_id=\"us.amazon.nova-2-lite-v1:0\",\n",
+    "    boto_client_config=quick_config\n",
+    ")\n",
+    "chatbot = Agent(tools=[web_search], model=chatbot_model, system_prompt=SYSTEM_PROMPT)\n",
+    "\n",
+    "# Initialize the AgentCore Runtime App\n",
+    "app = BedrockAgentCoreApp()\n",
+    "\n",
+    "\n",
+    "@app.entrypoint\n",
+    "def invoke(payload):\n",
+    "    \"\"\"AgentCore Runtime entrypoint function\"\"\"\n",
+    "    user_input = payload.get(\"prompt\", \"\")\n",
+    "    response = chatbot(user_input)\n",
+    "    return response.message[\"content\"][0][\"text\"]\n",
+    "\n",
+    "\n",
+    "if __name__ == \"__main__\":\n",
+    "    app.run()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "deploy",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bedrock_agentcore_starter_toolkit import Runtime\n",
+    "\n",
+    "agentcore_runtime = Runtime()\n",
+    "agentcore_runtime.configure(\n",
+    "    entrypoint=\"citysearch.py\",\n",
+    "    agent_name=\"citysearch_groundtruth_eval\",\n",
+    "    region=REGION,\n",
+    "    auto_create_execution_role=True,\n",
+    "    auto_create_ecr=True,\n",
+    "    requirements_file=\"requirements.txt\",\n",
+    "    non_interactive=True,\n",
+    ")\n",
+    "print(\"Configuration complete.\")\n",
+    "\n",
+    "print(\"\\nDeploying City Search Agent ...\")\n",
+    "print(\"  This takes ~5 minutes on first run (image build + push + runtime creation).\")\n",
+    "print()\n",
+    "\n",
+    "_launch = agentcore_runtime.launch(auto_update_on_conflict=True)\n",
+    "\n",
+    "print(f\"\\nLaunch complete.\")\n",
+    "print(f\"  agent_id  : {_launch.agent_id}\")\n",
+    "print(f\"  agent_arn : {_launch.agent_arn}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "wait-deploy",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "\n",
+    "print(\"Waiting for agent to reach READY status ...\")\n",
+    "\n",
+    "_POLL_INTERVAL = 15   # seconds between status checks\n",
+    "_MAX_WAIT      = 600  # 10-minute timeout\n",
+    "\n",
+    "_elapsed = 0\n",
+    "while _elapsed < _MAX_WAIT:\n",
+    "    _status_result = agentcore_runtime.status()\n",
+    "    _agent_info    = _status_result.agent or {}\n",
+    "    _agent_status  = _agent_info.get(\"status\", \"UNKNOWN\")\n",
+    "    print(f\"  [{_elapsed:>3}s] status = {_agent_status}\")\n",
+    "\n",
+    "    if _agent_status in (\"READY\", \"ACTIVE\"):\n",
+    "        print(f\"\\nAgent is {_agent_status}. Proceeding.\")\n",
+    "        break\n",
+    "    if _agent_status in (\"FAILED\", \"CREATE_FAILED\", \"UPDATE_FAILED\"):\n",
+    "        raise RuntimeError(\n",
+    "            f\"Agent deployment failed with status '{_agent_status}'.\\n\"\n",
+    "            f\"Details: {_agent_info}\"\n",
+    "        )\n",
+    "\n",
+    "    time.sleep(_POLL_INTERVAL)\n",
+    "    _elapsed += _POLL_INTERVAL\n",
+    "else:\n",
+    "    raise TimeoutError(\n",
+    "        f\"Agent did not reach READY status within {_MAX_WAIT}s. \"\n",
+    "        \"Check the AgentCore console for details.\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "agent-config",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "AGENT_ID     = _launch.agent_id\n",
+    "AGENT_ARN    = _launch.agent_arn\n",
+    "CW_LOG_GROUP = f\"/aws/bedrock-agentcore/runtimes/{AGENT_ID}-DEFAULT\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "store-agent",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Persist agent info\n",
+    "%store AGENT_ID\n",
+    "%store AGENT_ARN\n",
+    "%store CW_LOG_GROUP\n",
+    "%store REGION"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "e96d6c72-23d5-4de8-b4bb-99b683e992e9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# # Uncomment this if you need to restore the saved variables \n",
+    "# %store -r AGENT_ID\n",
+    "# %store -r AGENT_ARN\n",
+    "# %store -r CW_LOG_GROUP\n",
+    "# %store -r REGION"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d982015c-d36f-4167-b617-bfd54b6e87b0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"AGENT_ID     : {AGENT_ID}\")\n",
+    "print(f\"AGENT_ARN    : {AGENT_ARN}\")\n",
+    "print(f\"CW_LOG_GROUP : {CW_LOG_GROUP}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "86cc5e71-97fc-4c80-b051-94e6d2b44ec5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from botocore.config import Config\n",
+    "agentcore_config = Config(read_timeout=180, retries={\"max_attempts\": 2})\n",
+    "agentcore_client = boto3.client(\n",
+    "    \"bedrock-agentcore\", region_name=REGION, config=agentcore_config\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "invoke-md",
+   "metadata": {},
+   "source": [
+    "## Step 4: Invoke the Agent to Generate Sessions\n",
+    "\n",
+    "Before we can evaluate, we need agent sessions with CloudWatch spans. We'll invoke the agent\n",
+    "for several city search scenarios and record the session IDs for use with `EvaluationClient`.\n",
+    "\n",
+    "Each session corresponds to one evaluation scenario."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "invoke-helpers",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def invoke_agent(prompt: str, session_id: str) -> str:\n",
+    "    \"\"\"Send a single prompt to the city search agent and return its text response.\"\"\"\n",
+    "    resp = agentcore_client.invoke_agent_runtime(\n",
+    "        agentRuntimeArn=AGENT_ARN,\n",
+    "        qualifier=\"DEFAULT\",\n",
+    "        runtimeSessionId=session_id,\n",
+    "        payload=json.dumps({\"prompt\": prompt}),\n",
+    "    )\n",
+    "    response_body = resp[\"response\"].read()\n",
+    "    response_data = json.loads(response_body)\n",
+    "    return response_data if isinstance(response_data, str) else str(response_data)\n",
+    "\n",
+    "\n",
+    "def run_session(turns: list[str], session_prefix: str) -> str:\n",
+    "    \"\"\"Invoke a multi-turn session and return its session ID.\"\"\"\n",
+    "    session_id = f\"{session_prefix}-{uuid.uuid4()}\"\n",
+    "    print(f\"Session: {session_id}\")\n",
+    "    for turn_input in turns:\n",
+    "        print(f\"  > {turn_input[:70]}\")\n",
+    "        response = invoke_agent(turn_input, session_id)\n",
+    "        print(f\"  < {response[:100]}\")\n",
+    "    return session_id"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "invoke-single",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Single-Turn Sessions ===\n",
+      "Session: city-new-york-f32ebecd-0f3f-462d-80e2-2636a983a19f\n",
+      "  > How many people live in New York, and what's the area of the city in s\n",
+      "  < Based on the information I found, here are the details for New York City:\n",
+      "\n",
+      "**Population**: As of 202\n",
+      "Session: city-phoenix-f9a3e6c5-29f6-4421-a40e-2a4ff1baedac\n",
+      "  > What is the population and land area of Phoenix, AZ?\n",
+      "  < Based on the latest data:\n",
+      "\n",
+      "**Population**: Phoenix, AZ has an estimated population of approximately \n",
+      "Session: city-chicago-f4f5e3b1-66d6-4086-8e33-d55ccd24ba3a\n",
+      "  > How many people live in Chicago, IL, and what's the area of the city i\n",
+      "  < Based on the information I've gathered, here's the data for Chicago, IL:\n",
+      "\n",
+      "The population of Chicago \n",
+      "\n",
+      "Single-turn sessions created.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# --- Single-turn sessions ---\n",
+    "\n",
+    "print(\"=== Single-Turn Sessions ===\")\n",
+    "\n",
+    "session_new_york = run_session(\n",
+    "    [\"How many people live in New York, and what's the area of the city in square miles?\"],\n",
+    "    \"city-new-york\"\n",
+    ")\n",
+    "\n",
+    "session_phoenix = run_session(\n",
+    "    [\"What is the population and land area of Phoenix, AZ?\"],\n",
+    "    \"city-phoenix\"\n",
+    ")\n",
+    "\n",
+    "session_chicago = run_session(\n",
+    "    [\"How many people live in Chicago, IL, and what's the area of the city in square miles?\"],\n",
+    "    \"city-chicago\"\n",
+    ")\n",
+    "\n",
+    "print(\"\\nSingle-turn sessions created.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "invoke-multi",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Multi-Turn Session: City Comparison ===\n",
+      "Session: city-comparison-session-8127ad8d-37b3-439a-8930-d83ca22eeefa\n",
+      "  > What is the population and area of Los Angeles, CA?\n",
+      "  < Based on the search results, here is the information for Los Angeles, CA:\n",
+      "\n",
+      "**Population:** Approxima\n",
+      "  > Now look up the same info for Houston, TX.\n",
+      "  < Based on the search results, here is the information for Houston, TX:\n",
+      "\n",
+      "**Population:** Approximately\n",
+      "  > Which of the two cities has a higher population density?\n",
+      "  < To determine which city has a higher population density, we need to calculate the population density\n",
+      "\n",
+      "Multi-turn session created.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# --- Multi-turn session: Comparing cities ---\n",
+    "\n",
+    "print(\"=== Multi-Turn Session: City Comparison ===\")\n",
+    "\n",
+    "session_city_comparison = run_session(\n",
+    "    [\n",
+    "        \"What is the population and area of Los Angeles, CA?\",\n",
+    "        \"Now look up the same info for Houston, TX.\",\n",
+    "        \"Which of the two cities has a higher population density?\",\n",
+    "    ],\n",
+    "    \"city-comparison-session\"\n",
+    ")\n",
+    "\n",
+    "print(\"\\nMulti-turn session created.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "invoke-multi2",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Multi-Turn Session: Regional Exploration ===\n",
+      "Session: regional-exploration-ed52dda6-c11b-4a23-8ed6-7d57ab107dfe\n",
+      "  > What is the population and area of Seattle, WA?\n",
+      "  < Based on the information retrieved, here are the key details for Seattle, WA:\n",
+      "\n",
+      "**Population**: Seatt\n",
+      "  > How about San Francisco, CA?\n",
+      "  < Based on the retrieved data, here are the key details for San Francisco, CA:\n",
+      "\n",
+      "**Population**: The ci\n",
+      "  > And Denver, CO?\n",
+      "  < Based on the retrieved data, here are the key details for Denver, CO:\n",
+      "\n",
+      "**Population**: Denver has a \n",
+      "\n",
+      "All sessions created. Waiting 60s for CloudWatch log ingestion...\n",
+      "Ready to evaluate.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# --- Multi-turn session: Regional exploration ---\n",
+    "\n",
+    "print(\"=== Multi-Turn Session: Regional Exploration ===\")\n",
+    "\n",
+    "session_regional = run_session(\n",
+    "    [\n",
+    "        \"What is the population and area of Seattle, WA?\",\n",
+    "        \"How about San Francisco, CA?\",\n",
+    "        \"And Denver, CO?\",\n",
+    "    ],\n",
+    "    \"regional-exploration\"\n",
+    ")\n",
+    "\n",
+    "print(\"\\nAll sessions created. Waiting 60s for CloudWatch log ingestion...\")\n",
+    "time.sleep(60)\n",
+    "print(\"Ready to evaluate.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eval-client-md",
+   "metadata": {},
+   "source": [
+    "## Step 5: EvaluationClient — Evaluate Existing Sessions\n",
+    "\n",
+    "`EvaluationClient` is the right tool when you **already have agent sessions** logged in CloudWatch and you want to test them against your ground truth in an ad-hoc manner.\n",
+    "It looks up the agent's spans for a given `session_id` and runs evaluators against them. For these evaluations, you can pass in an expected response, assertions, and expected trajectory. You can use the built-in evaluators as well as custom evaluators.\n",
+    "\n",
+    "### Ground-Truth Reference Inputs\n",
+    "\n",
+    "`ReferenceInputs` lets you supply optional ground truth:\n",
+    "\n",
+    "| Field | Evaluators that use it | Description |\n",
+    "|---|---|---|\n",
+    "| `expected_response` | `Builtin.Correctness` | The ideal response text |\n",
+    "| `expected_trajectory` | `Builtin.TrajectoryExactOrderMatch`, `Builtin.TrajectoryInOrderMatch`, `Builtin.TrajectoryAnyOrderMatch` | Ordered list of tool names |\n",
+    "| `assertions` | `Builtin.GoalSuccessRate` | Free-text assertions the session should satisfy |\n",
+    "\n",
+    "Evaluators that don't need ground truth (`Helpfulness`, `ResponseRelevance`) can be included in the same call.\n",
+    "Each evaluator only reads the fields it needs."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "custom-eval-md",
+   "metadata": {},
+   "source": [
+    "### Create Custom (LLM-as-a-Judge) Evaluators\n",
+    "\n",
+    "In addition to built-in evaluators, you can define your own evaluation criteria using\n",
+    "**LLM-as-a-Judge custom evaluators**. These accept natural language instructions that\n",
+    "can reference **ground truth placeholders** automatically substituted at evaluation time.\n",
+    "\n",
+    "#### Ground truth placeholders\n",
+    "\n",
+    "| Level | Available placeholders |\n",
+    "|---|---|\n",
+    "| **TRACE** | `{context}`, `{assistant_turn}`, `{expected_response}` |\n",
+    "| **SESSION** | `{context}`, `{available_tools}`, `{actual_tool_trajectory}`, `{expected_tool_trajectory}`, `{assertions}` |\n",
+    "\n",
+    "For example, a trace-level evaluator comparing response similarity would include\n",
+    "`{assistant_turn}` and `{expected_response}` in its instructions. When the evaluator runs,\n",
+    "the service substitutes those placeholders with the actual agent output and the\n",
+    "`expectedResponse` from `ReferenceInputs`.\n",
+    "\n",
+    "#### What we'll create\n",
+    "\n",
+    "| Evaluator | Level | Placeholders | Description |\n",
+    "|---|---|---|---|\n",
+    "| `CityResponseSimilarity` | TRACE | `{assistant_turn}`, `{expected_response}` | How closely the agent's city data matches the expected answer |\n",
+    "| `CityAssertionChecker` | SESSION | `{actual_tool_trajectory}`, `{expected_tool_trajectory}`, `{assertions}` | Whether the agent called the right tools and satisfied all session assertions |"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "create-custom-evaluators",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Creating CityResponseSimilarity (TRACE) ...\n",
+      "  evaluatorId : CityResponseSimilarity_97db3e15-qX3R8q44BV\n",
+      "\n",
+      "Creating CityAssertionChecker (SESSION) ...\n",
+      "  evaluatorId : CityAssertionChecker_97db3e15-aILiOJ37l4\n",
+      "\n",
+      "Custom evaluators ready:\n",
+      "  CityResponseSimilarity (TRACE)   : CityResponseSimilarity_97db3e15-qX3R8q44BV\n",
+      "  CityAssertionChecker   (SESSION) : CityAssertionChecker_97db3e15-aILiOJ37l4\n"
+     ]
+    }
+   ],
+   "source": [
+    "import uuid\n",
+    "\n",
+    "_SUFFIX = uuid.uuid4().hex[:8]\n",
+    "_cp = boto3.client(\"bedrock-agentcore-control\", region_name=REGION)\n",
+    "\n",
+    "# ---------------------------------------------------------------------------\n",
+    "# Trace-level: CityResponseSimilarity\n",
+    "# Compares the agent's response to the expected_response reference input.\n",
+    "# {assistant_turn} -> actual agent output\n",
+    "# {expected_response} -> expectedResponse field in ReferenceInputs\n",
+    "# ---------------------------------------------------------------------------\n",
+    "print(\"Creating CityResponseSimilarity (TRACE) ...\")\n",
+    "_resp_sim = _cp.create_evaluator(\n",
+    "    evaluatorName=f\"CityResponseSimilarity_{_SUFFIX}\",\n",
+    "    level=\"TRACE\",\n",
+    "    evaluatorConfig={\n",
+    "        \"llmAsAJudge\": {\n",
+    "            \"instructions\": (\n",
+    "                \"Compare the agent's response with the expected response about city data.\\n\"\n",
+    "                \"Agent response: {assistant_turn}\\n\"\n",
+    "                \"Expected response: {expected_response}\\n\\n\"\n",
+    "                \"Rate how closely the agent's response matches the expected response. \"\n",
+    "                \"Focus on whether the population numbers and area figures are accurate.\"\n",
+    "            ),\n",
+    "            \"ratingScale\": {\n",
+    "                \"numerical\": [\n",
+    "                    {\n",
+    "                        \"value\": 0.0,\n",
+    "                        \"label\": \"not_similar\",\n",
+    "                        \"definition\": \"Response has significantly different population or area numbers from the expected response.\",\n",
+    "                    },\n",
+    "                    {\n",
+    "                        \"value\": 0.5,\n",
+    "                        \"label\": \"partially_similar\",\n",
+    "                        \"definition\": \"Response has one correct figure but the other is wrong or missing.\",\n",
+    "                    },\n",
+    "                    {\n",
+    "                        \"value\": 1.0,\n",
+    "                        \"label\": \"highly_similar\",\n",
+    "                        \"definition\": \"Response is semantically equivalent — population and area figures are close to expected values.\",\n",
+    "                    },\n",
+    "                ]\n",
+    "            },\n",
+    "            \"modelConfig\": {\n",
+    "                \"bedrockEvaluatorModelConfig\": {\n",
+    "                    \"modelId\": \"us.amazon.nova-lite-v1:0\",\n",
+    "                    \"inferenceConfig\": {\"maxTokens\": 512},\n",
+    "                }\n",
+    "            },\n",
+    "        }\n",
+    "    },\n",
+    ")\n",
+    "CUSTOM_RESPONSE_SIMILARITY_ID = _resp_sim[\"evaluatorId\"]\n",
+    "print(f\"  evaluatorId : {CUSTOM_RESPONSE_SIMILARITY_ID}\")\n",
+    "\n",
+    "# ---------------------------------------------------------------------------\n",
+    "# Session-level: CityAssertionChecker\n",
+    "# Evaluates tool trajectory compliance and assertion satisfaction.\n",
+    "# {actual_tool_trajectory}   -> tools the agent actually called\n",
+    "# {expected_tool_trajectory} -> expectedTrajectory from ReferenceInputs\n",
+    "# {assertions}               -> assertions list from ReferenceInputs\n",
+    "# ---------------------------------------------------------------------------\n",
+    "print(\"\\nCreating CityAssertionChecker (SESSION) ...\")\n",
+    "_assert_chk = _cp.create_evaluator(\n",
+    "    evaluatorName=f\"CityAssertionChecker_{_SUFFIX}\",\n",
+    "    level=\"SESSION\",\n",
+    "    evaluatorConfig={\n",
+    "        \"llmAsAJudge\": {\n",
+    "            \"instructions\": (\n",
+    "                \"Evaluate whether the agent fulfilled the session requirements.\\n\\n\"\n",
+    "                \"Expected tool trajectory: {expected_tool_trajectory}\\n\"\n",
+    "                \"Actual tool trajectory: {actual_tool_trajectory}\\n\"\n",
+    "                \"Assertions to verify: {assertions}\\n\\n\"\n",
+    "                \"Score the agent on how well it followed the expected tool trajectory \"\n",
+    "                \"and satisfied every listed assertion.\"\n",
+    "            ),\n",
+    "            \"ratingScale\": {\n",
+    "                \"numerical\": [\n",
+    "                    {\n",
+    "                        \"value\": 0.0,\n",
+    "                        \"label\": \"failed\",\n",
+    "                        \"definition\": \"Agent did not follow the trajectory and failed most assertions.\",\n",
+    "                    },\n",
+    "                    {\n",
+    "                        \"value\": 0.5,\n",
+    "                        \"label\": \"partial\",\n",
+    "                        \"definition\": \"Agent partially followed the trajectory or satisfied only some assertions.\",\n",
+    "                    },\n",
+    "                    {\n",
+    "                        \"value\": 1.0,\n",
+    "                        \"label\": \"passed\",\n",
+    "                        \"definition\": \"Agent followed the expected trajectory and satisfied all assertions.\",\n",
+    "                    },\n",
+    "                ]\n",
+    "            },\n",
+    "            \"modelConfig\": {\n",
+    "                \"bedrockEvaluatorModelConfig\": {\n",
+    "                    \"modelId\": \"us.amazon.nova-lite-v1:0\",\n",
+    "                    \"inferenceConfig\": {\"maxTokens\": 512},\n",
+    "                }\n",
+    "            },\n",
+    "        }\n",
+    "    },\n",
+    ")\n",
+    "CUSTOM_ASSERTION_CHECKER_ID = _assert_chk[\"evaluatorId\"]\n",
+    "print(f\"  evaluatorId : {CUSTOM_ASSERTION_CHECKER_ID}\")\n",
+    "\n",
+    "print(f\"\\nCustom evaluators ready:\")\n",
+    "print(f\"  CityResponseSimilarity (TRACE)   : {CUSTOM_RESPONSE_SIMILARITY_ID}\")\n",
+    "print(f\"  CityAssertionChecker   (SESSION) : {CUSTOM_ASSERTION_CHECKER_ID}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "eval-client-init",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "EvaluationClient initialised (region=us-west-2)\n",
+      "  CityResponseSimilarity_97db3e15-qX3R8q44BV -> TRACE  (custom: CityResponseSimilarity)\n",
+      "  CityAssertionChecker_97db3e15-aILiOJ37l4 -> SESSION (custom: CityAssertionChecker)\n"
+     ]
+    }
+   ],
+   "source": [
+    "from bedrock_agentcore.evaluation import EvaluationClient, ReferenceInputs\n",
+    "\n",
+    "eval_client = EvaluationClient(region_name=REGION)\n",
+    "\n",
+    "print(f\"EvaluationClient initialised (region={REGION})\")\n",
+    "print(f\"  {CUSTOM_RESPONSE_SIMILARITY_ID} -> TRACE  (custom: CityResponseSimilarity)\")\n",
+    "print(f\"  {CUSTOM_ASSERTION_CHECKER_ID} -> SESSION (custom: CityAssertionChecker)\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "print-helper",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Helper function for printing\n",
+    "def display_eval_results(label: str, results: list) -> None:\n",
+    "    \"\"\"Pretty-print EvaluationClient results as a markdown table.\"\"\"\n",
+    "    rows = [\"| Evaluator | Value | Label | Explanation |\",\n",
+    "            \"|---|---|---|---|\"]\n",
+    "    for r in results:\n",
+    "        evaluator = r.get(\"evaluatorId\", \"\")[:40]\n",
+    "        value = str(r.get(\"value\", r.get(\"score\", \"N/A\")))\n",
+    "        lbl = str(r.get(\"label\", r.get(\"rating\", \"\")))\n",
+    "        explanation = (r.get(\"explanation\", r.get(\"reason\", \"\")) or \"\")[:120].replace(\"\\n\", \" \")\n",
+    "        error_code = r.get(\"errorCode\")\n",
+    "        if error_code:\n",
+    "            lbl = f\"ERR:{error_code}\"\n",
+    "            explanation = (r.get(\"errorMessage\", \"\") or \"\")[:120]\n",
+    "        rows.append(f\"| `{evaluator}` | {value} | {lbl} | {explanation} |\")\n",
+    "\n",
+    "    if len(rows) == 2:  # only header rows, no data\n",
+    "        rows.append(\"| No results — session may be too recent or spans not yet visible | | | |\")\n",
+    "\n",
+    "    md = f\"### {label}\\n\\n\" + \"\\n\".join(rows)\n",
+    "    display(Markdown(md))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ec-single-md",
+   "metadata": {},
+   "source": [
+    "### 5a. Single-Turn: New York — Correctness + Helpfulness + Custom ResponseSimilarity\n",
+    "\n",
+    "We evaluate the New York city search response against known ground truth data from our `city_pop.csv` dataset using `Builtin.Correctness` and the custom `CityResponseSimilarity` evaluator. Both measure factual accuracy but use different scoring rubrics."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "ec-new-york",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "### New York — Correctness + Quality + Custom ResponseSimilarity\n",
+       "\n",
+       "| Evaluator | Value | Label | Explanation |\n",
+       "|---|---|---|---|\n",
+       "| `Builtin.Correctness` | 1.0 | Correct | The agent response provides population and area figures for New York City that are close to the expected response but wi |\n",
+       "| `Builtin.Helpfulness` | 0.83 | Very Helpful | The user's goal is straightforward: obtain the population and area (in square miles) of New York City. The assistant's r |\n",
+       "| `Builtin.ResponseRelevance` | 1.0 | Completely Yes | The user asked two specific questions: (1) How many people live in New York, and (2) what's the area of the city in squa |\n",
+       "| `CityResponseSimilarity_97db3e15-qX3R8q44` | 0.5 | partially_similar | The agent's response provides a population figure of approximately 8.8 million, which is slightly higher than the expect |"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "new_york_results = eval_client.run(\n",
+    "    evaluator_ids=[\n",
+    "        \"Builtin.Correctness\",           # TRACE: compares with provided expected response\n",
+    "        \"Builtin.Helpfulness\",           # TRACE: no ground truth needed\n",
+    "        \"Builtin.ResponseRelevance\",     # TRACE: no ground truth needed\n",
+    "        CUSTOM_RESPONSE_SIMILARITY_ID,   # TRACE: custom — uses {assistant_turn} + {expected_response}\n",
+    "    ],\n",
+    "    session_id=session_new_york,\n",
+    "    agent_id=AGENT_ID,\n",
+    "    look_back_time=timedelta(hours=2),\n",
+    "    reference_inputs=ReferenceInputs(\n",
+    "        expected_response=\"New York has a population of approximately 8,478,072 people and a land area of about 300.5 square miles.\",\n",
+    "    ),\n",
+    ")\n",
+    "\n",
+    "display_eval_results(\"New York — Correctness + Quality + Custom ResponseSimilarity\", new_york_results)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ec-traj-md",
+   "metadata": {},
+   "source": [
+    "### 5b. Single-Turn: Phoenix — Assertions + Trajectory + Custom AssertionChecker\n",
+    "\n",
+    "This cell runs both built-in trajectory evaluators **and** the custom `CityAssertionChecker`\n",
+    "(which uses `{actual_tool_trajectory}`, `{expected_tool_trajectory}`, and `{assertions}` placeholders)\n",
+    "plus the custom `CityResponseSimilarity` for the response. This lets you compare built-in vs. custom\n",
+    "scoring side by side."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "ec-phoenix",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "### Phoenix — Built-in + Custom ResponseSimilarity\n",
+       "\n",
+       "| Evaluator | Value | Label | Explanation |\n",
+       "|---|---|---|---|\n",
+       "| `Builtin.GoalSuccessRate` | 1.0 | Yes | The agent successfully completed all three assertions: (1) It called web_search multiple times to look up Phoenix popula |\n",
+       "| `Builtin.TrajectoryExactOrderMatch` | 0.0 | No | Length mismatch: Expected 1 tools ['web_search'], but got 3 tools ['web_search', 'web_search', 'web_search'] |\n",
+       "| `Builtin.TrajectoryAnyOrderMatch` | 1.0 | Yes | Any-order match: All expected tools ['web_search'] found in actual ['web_search', 'web_search', 'web_search'] |\n",
+       "| `Builtin.Correctness` | 1.0 | Correct | The agent response provides population and land area figures for Phoenix, AZ that are very close to the expected respons |\n",
+       "| `CityResponseSimilarity_97db3e15-qX3R8q44` | 1.0 | highly_similar | The agent's response has a population figure that is slightly higher than the expected response (1,706,000 vs. 1,673,164 |"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "phoenix_results = eval_client.run(\n",
+    "    evaluator_ids=[\n",
+    "        \"Builtin.GoalSuccessRate\",           # SESSION: built-in assertion evaluator\n",
+    "        \"Builtin.TrajectoryExactOrderMatch\", # SESSION: built-in trajectory evaluator\n",
+    "        \"Builtin.TrajectoryAnyOrderMatch\",   # SESSION: built-in trajectory evaluator\n",
+    "        \"Builtin.Correctness\",               # TRACE: built-in response accuracy\n",
+    "        CUSTOM_RESPONSE_SIMILARITY_ID,       # TRACE (custom): {assistant_turn} + {expected_response}\n",
+    "    ],\n",
+    "    session_id=session_phoenix,\n",
+    "    agent_id=AGENT_ID,\n",
+    "    look_back_time=timedelta(hours=2),\n",
+    "    reference_inputs=ReferenceInputs(\n",
+    "        expected_trajectory=[\"web_search\"],\n",
+    "        assertions=[\n",
+    "            \"Agent called web_search to look up Phoenix population and area data\",\n",
+    "            \"Agent reported a population close to 1,673,164 for Phoenix, AZ\",\n",
+    "            \"Agent reported a land area close to 518 square miles for Phoenix, AZ\",\n",
+    "        ],\n",
+    "        expected_response=\"Phoenix, AZ has a population of approximately 1,673,164 and a land area of about 518 square miles.\",\n",
+    "    ),\n",
+    ")\n",
+    "\n",
+    "display_eval_results(\"Phoenix — Built-in + Custom ResponseSimilarity\", phoenix_results)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ec-chicago-md",
+   "metadata": {},
+   "source": [
+    "### 5c. Single-Turn: Chicago — Factual Correctness\n",
+    "\n",
+    "Factual data retrieval scenarios are well-suited for `Builtin.Correctness` combined with\n",
+    "`Builtin.GoalSuccessRate`. The expected_response provides the ground truth figures."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "ec-chicago",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "### Chicago — Correctness + GoalSuccessRate\n",
+       "\n",
+       "| Evaluator | Value | Label | Explanation |\n",
+       "|---|---|---|---|\n",
+       "| `Builtin.Correctness` | 1.0 | Correct | The agent response provides population and area data for Chicago, IL. Comparing to the expected response:  Population: A |\n",
+       "| `Builtin.GoalSuccessRate` | 1.0 | Yes | The agent successfully completed all three assertions: (1) It called web_search multiple times to gather information abo |"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "chicago_results = eval_client.run(\n",
+    "    evaluator_ids=[\n",
+    "        \"Builtin.Correctness\",\n",
+    "        \"Builtin.GoalSuccessRate\",\n",
+    "    ],\n",
+    "    session_id=session_chicago,\n",
+    "    agent_id=AGENT_ID,\n",
+    "    look_back_time=timedelta(hours=2),\n",
+    "    reference_inputs=ReferenceInputs(\n",
+    "        expected_response=\"Chicago, IL has a population of approximately 2,721,308 and a land area of about 227.7 square miles.\",\n",
+    "        assertions=[\n",
+    "            \"Agent called web_search for Chicago population and area\",\n",
+    "            \"Agent reported a population close to 2,721,308\",\n",
+    "            \"Agent reported a land area close to 227.7 square miles\",\n",
+    "        ],\n",
+    "    ),\n",
+    ")\n",
+    "\n",
+    "display_eval_results(\"Chicago — Correctness + GoalSuccessRate\", chicago_results)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ec-multi-md",
+   "metadata": {},
+   "source": [
+    "### 5d. Multi-Turn: City Comparison Session (3 turns) + Custom AssertionChecker\n",
+    "\n",
+    "For multi-turn sessions, `EvaluationClient` fetches all spans for the session and evaluates\n",
+    "the complete conversation. The trajectory and assertions apply across all turns.\n",
+    "\n",
+    "This scenario exercises the custom `CityAssertionChecker` evaluator (SESSION level),\n",
+    "which uses `{actual_tool_trajectory}`, `{expected_tool_trajectory}`, and `{assertions}`\n",
+    "placeholders. A 3-turn session with distinct queries per turn gives the evaluator\n",
+    "a rich trajectory to compare against the expected sequence."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "ec-multi-comparison",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "### City Comparison — Multi-Turn (3 turns) + Custom AssertionChecker\n",
+       "\n",
+       "| Evaluator | Value | Label | Explanation |\n",
+       "|---|---|---|---|\n",
+       "| `Builtin.GoalSuccessRate` | 1.0 | Yes | The agent successfully completed all required tasks across the three turns:  1. Turn 1: Agent performed web searches for |\n",
+       "| `Builtin.TrajectoryExactOrderMatch` | 0.0 | No | Length mismatch: Expected 2 tools ['web_search', 'web_search'], but got 6 tools ['web_search', 'web_search', 'web_search |\n",
+       "| `Builtin.TrajectoryInOrderMatch` | 1.0 | Yes | In-order match: All expected tools ['web_search', 'web_search'] found in order within actual ['web_search', 'web_search' |\n",
+       "| `Builtin.TrajectoryAnyOrderMatch` | 1.0 | Yes | Any-order match: All expected tools ['web_search', 'web_search'] found in actual ['web_search', 'web_search', 'web_searc |\n",
+       "| `Builtin.Helpfulness` | 0.83 | Very Helpful | The user's goal is straightforward: obtain the population and land area of Los Angeles, CA. The assistant's response dir |\n",
+       "| `Builtin.Helpfulness` | 0.83 | Very Helpful | The user's goal is clear: obtain the population and land area for Houston, TX, following their previous request for the  |\n",
+       "| `Builtin.Helpfulness` | 0.83 | Very Helpful | The user's goal is to determine which of the two cities (Los Angeles and Houston) has a higher population density. The a |\n",
+       "| `CityAssertionChecker_97db3e15-aILiOJ37l4` | 0.5 |  | The agent followed an unexpected trajectory by performing six web searches instead of the expected two. Despite this, th |"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "comparison_results = eval_client.run(\n",
+    "    evaluator_ids=[\n",
+    "        \"Builtin.GoalSuccessRate\",\n",
+    "        \"Builtin.TrajectoryExactOrderMatch\",\n",
+    "        \"Builtin.TrajectoryInOrderMatch\",\n",
+    "        \"Builtin.TrajectoryAnyOrderMatch\",\n",
+    "        \"Builtin.Helpfulness\",\n",
+    "        CUSTOM_ASSERTION_CHECKER_ID,   # SESSION (custom): trajectory + assertions\n",
+    "    ],\n",
+    "    session_id=session_city_comparison,\n",
+    "    agent_id=AGENT_ID,\n",
+    "    look_back_time=timedelta(hours=2),\n",
+    "    reference_inputs=ReferenceInputs(\n",
+    "        expected_trajectory=[\"web_search\", \"web_search\"],\n",
+    "        assertions=[\n",
+    "            \"Agent looked up population and area for Los Angeles in turn 1\",\n",
+    "            \"Agent looked up population and area for Houston in turn 2\",\n",
+    "            \"Agent compared population density between the two cities in turn 3\",\n",
+    "            \"Agent correctly identified that Los Angeles has a higher population density than Houston\",\n",
+    "        ],\n",
+    "    ),\n",
+    ")\n",
+    "\n",
+    "display_eval_results(\"City Comparison — Multi-Turn (3 turns) + Custom AssertionChecker\", comparison_results)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "runner-md",
+   "metadata": {},
+   "source": [
+    "## Step 6: OnDemandEvaluationDatasetRunner — Automated Dataset Evaluation\n",
+    "\n",
+    "`OnDemandEvaluationDatasetRunner` is the right tool when you have a **test dataset** and want to:\n",
+    "1. Automatically invoke your agent for each scenario\n",
+    "2. Collect CloudWatch spans\n",
+    "3. Run evaluators against each scenario's results\n",
+    "\n",
+    "This is ideal for regression testing, CI/CD pipelines, and batch evaluation against curated datasets.\n",
+    "\n",
+    "### Dataset structure\n",
+    "\n",
+    "A dataset consists of **scenarios**, each with one or more **turns**. Optional ground-truth fields:\n",
+    "- `Turn.expected_response` — per-turn expected answer\n",
+    "- `PreDefinedScenario.expected_trajectory` — ordered list of tool names\n",
+    "- `PreDefinedScenario.assertions` — session-level assertions\n",
+    "\n",
+    "### How OnDemandEvaluationDatasetRunner works\n",
+    "\n",
+    "```\n",
+    "For each scenario:\n",
+    "  1. Create a new session ID\n",
+    "  2. Call your agent_invoker function for each turn\n",
+    "  3. Wait for CloudWatch spans to appear (evaluation_delay_seconds)\n",
+    "  4. Submit spans + ground truth to the evaluation service\n",
+    "  5. Collect and return results\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "runner-imports",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bedrock_agentcore.evaluation import (\n",
+    "    AgentInvokerInput,\n",
+    "    AgentInvokerOutput,\n",
+    "    CloudWatchAgentSpanCollector,\n",
+    "    Dataset,\n",
+    "    EvaluationRunConfig,\n",
+    "    OnDemandEvaluationDatasetRunner,\n",
+    "    EvaluatorConfig,\n",
+    "    Turn,\n",
+    "    PredefinedScenario,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "runner-invoker",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def agent_invoker(invoker_input: AgentInvokerInput) -> AgentInvokerOutput:\n",
+    "    \"\"\"\n",
+    "    Called by OnDemandEvaluationDatasetRunner once per turn. Invoke the city search\n",
+    "    agent and return the text response.\n",
+    "    \"\"\"\n",
+    "    payload = invoker_input.payload\n",
+    "    body = {\"prompt\": payload} if isinstance(payload, str) else payload\n",
+    "\n",
+    "    resp = agentcore_client.invoke_agent_runtime(\n",
+    "        agentRuntimeArn=AGENT_ARN,\n",
+    "        qualifier=\"DEFAULT\",\n",
+    "        runtimeSessionId=invoker_input.session_id,\n",
+    "        payload=json.dumps(body),\n",
+    "    )\n",
+    "\n",
+    "    response_body = resp[\"response\"].read()\n",
+    "    response_data = json.loads(response_body)\n",
+    "    return AgentInvokerOutput(\n",
+    "        agent_output=response_data if isinstance(response_data, str) else str(response_data)\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "runner-dataset-md",
+   "metadata": {},
+   "source": [
+    "### 6a. Define the Evaluation Dataset\n",
+    "\n",
+    "We define scenarios inline using ground truth data from the `city_pop.csv` dataset. A mix of single-turn and multi-turn scenarios exercises different aspects of the agent."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "runner-dataset",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dataset contains 5 scenarios.\n"
+     ]
+    }
+   ],
+   "source": [
+    "dataset = Dataset(\n",
+    "    scenarios=[\n",
+    "        # --- Single-turn: New York population and area ---\n",
+    "        PredefinedScenario(\n",
+    "            scenario_id=\"city-new-york\",\n",
+    "            turns=[\n",
+    "                Turn(\n",
+    "                    input=\"How many people live in New York, and what's the area of the city in square miles?\",\n",
+    "                    expected_response=\"New York has a population of approximately 8,478,072 and a land area of about 300.5 square miles.\",\n",
+    "                )\n",
+    "            ],\n",
+    "            expected_trajectory=[\"web_search\"],\n",
+    "            assertions=[\n",
+    "                \"Agent called web_search to look up New York population and area\",\n",
+    "                \"Agent reported a population close to 8,478,072\",\n",
+    "                \"Agent reported a land area close to 300.5 square miles\",\n",
+    "            ],\n",
+    "        ),\n",
+    "\n",
+    "        # --- Single-turn: Los Angeles ---\n",
+    "        PredefinedScenario(\n",
+    "            scenario_id=\"city-los-angeles\",\n",
+    "            turns=[\n",
+    "                Turn(\n",
+    "                    input=\"What is the population and land area of Los Angeles, CA?\",\n",
+    "                    expected_response=\"Los Angeles has a population of approximately 3,878,704 and a land area of about 469.5 square miles.\",\n",
+    "                )\n",
+    "            ],\n",
+    "            expected_trajectory=[\"web_search\"],\n",
+    "            assertions=[\n",
+    "                \"Agent called web_search to look up Los Angeles data\",\n",
+    "                \"Agent reported a population close to 3,878,704\",\n",
+    "                \"Agent reported a land area close to 469.5 square miles\",\n",
+    "            ],\n",
+    "        ),\n",
+    "\n",
+    "        # --- Single-turn: Houston ---\n",
+    "        PredefinedScenario(\n",
+    "            scenario_id=\"city-houston\",\n",
+    "            turns=[\n",
+    "                Turn(\n",
+    "                    input=\"How many people live in Houston, TX, and what's the area of the city in square miles?\",\n",
+    "                    expected_response=\"Houston has a population of approximately 2,390,125 and a land area of about 640.4 square miles.\",\n",
+    "                )\n",
+    "            ],\n",
+    "            expected_trajectory=[\"web_search\"],\n",
+    "            assertions=[\n",
+    "                \"Agent called web_search to look up Houston data\",\n",
+    "                \"Agent reported a population close to 2,390,125\",\n",
+    "                \"Agent reported a land area close to 640.4 square miles\",\n",
+    "            ],\n",
+    "        ),\n",
+    "\n",
+    "        # --- Single-turn: San Francisco ---\n",
+    "        PredefinedScenario(\n",
+    "            scenario_id=\"city-san-francisco\",\n",
+    "            turns=[\n",
+    "                Turn(\n",
+    "                    input=\"What is the population and land area of San Francisco, CA?\",\n",
+    "                    expected_response=\"San Francisco has a population of approximately 827,526 and a land area of about 46.9 square miles.\",\n",
+    "                )\n",
+    "            ],\n",
+    "            expected_trajectory=[\"web_search\"],\n",
+    "            assertions=[\n",
+    "                \"Agent called web_search to look up San Francisco data\",\n",
+    "                \"Agent reported a population close to 827,526\",\n",
+    "                \"Agent reported a land area close to 46.9 square miles\",\n",
+    "            ],\n",
+    "        ),\n",
+    "\n",
+    "        # --- Multi-turn: Comparing two cities ---\n",
+    "        PredefinedScenario(\n",
+    "            scenario_id=\"city-comparison-multi\",\n",
+    "            turns=[\n",
+    "                Turn(\n",
+    "                    input=\"What is the population and area of Seattle, WA?\",\n",
+    "                    expected_response=\"Seattle has a population of approximately 780,995 and a land area of about 83.8 square miles.\",\n",
+    "                ),\n",
+    "                Turn(\n",
+    "                    input=\"Now look up the same for Denver, CO.\",\n",
+    "                    expected_response=\"Denver has a population of approximately 729,019 and a land area of about 153.1 square miles.\",\n",
+    "                ),\n",
+    "                Turn(\n",
+    "                    input=\"Which city has a higher population density?\",\n",
+    "                    expected_response=\"Seattle has a higher population density than Denver because it has a larger population in a much smaller area.\",\n",
+    "                ),\n",
+    "            ],\n",
+    "            expected_trajectory=[\"web_search\", \"web_search\"],\n",
+    "            assertions=[\n",
+    "                \"Agent called web_search twice across the conversation for Seattle and Denver\",\n",
+    "                \"Agent correctly reported population and area for both cities\",\n",
+    "                \"Agent correctly identified Seattle as having higher population density\",\n",
+    "            ],\n",
+    "        ),\n",
+    "    ]\n",
+    ")\n",
+    "\n",
+    "print(f\"Dataset contains {len(dataset.scenarios)} scenarios.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "runner-config-md",
+   "metadata": {},
+   "source": [
+    "### 6b. Configure and Run OnDemandEvaluationDatasetRunner"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "runner-config",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "OnDemandEvaluationDatasetRunner configured. Starting evaluation...\n",
+      "  Scenarios : 5\n",
+      "  Evaluators: 7 (5 built-in + 2 custom)\n",
+      "  Delay     : 180s (waiting for CloudWatch ingestion)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Span collector: polls CloudWatch for OTel spans emitted by the agent\n",
+    "span_collector = CloudWatchAgentSpanCollector(\n",
+    "    log_group_name=CW_LOG_GROUP,\n",
+    "    region=REGION,\n",
+    "    max_wait_seconds=180,\n",
+    "    poll_interval_seconds=15,\n",
+    ")\n",
+    "\n",
+    "# Evaluator level cache — built-ins + custom evaluators\n",
+    "EVALUATOR_LEVELS = {\n",
+    "    \"Builtin.GoalSuccessRate\":            \"SESSION\",\n",
+    "    \"Builtin.TrajectoryExactOrderMatch\":  \"SESSION\",\n",
+    "    \"Builtin.TrajectoryInOrderMatch\":     \"SESSION\",\n",
+    "    \"Builtin.TrajectoryAnyOrderMatch\":    \"SESSION\",\n",
+    "    \"Builtin.Correctness\":                \"TRACE\",\n",
+    "}\n",
+    "# Custom evaluators\n",
+    "EVALUATOR_LEVELS[CUSTOM_RESPONSE_SIMILARITY_ID] = \"TRACE\"\n",
+    "EVALUATOR_LEVELS[CUSTOM_ASSERTION_CHECKER_ID]   = \"SESSION\"\n",
+    "\n",
+    "# Evaluator configuration — mix of built-in and custom evaluators\n",
+    "config = EvaluationRunConfig(\n",
+    "    evaluator_config=EvaluatorConfig(\n",
+    "        evaluator_ids=[\n",
+    "            \"Builtin.Correctness\",               # TRACE — expected_response\n",
+    "            \"Builtin.GoalSuccessRate\",            # SESSION — assertions\n",
+    "            \"Builtin.TrajectoryExactOrderMatch\",  # SESSION — expected_trajectory\n",
+    "            \"Builtin.TrajectoryInOrderMatch\",     # SESSION — expected_trajectory\n",
+    "            \"Builtin.TrajectoryAnyOrderMatch\",    # SESSION — expected_trajectory\n",
+    "            CUSTOM_RESPONSE_SIMILARITY_ID,       # TRACE (custom) — {assistant_turn} + {expected_response}\n",
+    "            CUSTOM_ASSERTION_CHECKER_ID,         # SESSION (custom) — {actual_tool_trajectory} + {assertions}\n",
+    "        ]\n",
+    "    ),\n",
+    "    evaluation_delay_seconds=180,\n",
+    "    max_concurrent_scenarios=3,\n",
+    ")\n",
+    "\n",
+    "runner = OnDemandEvaluationDatasetRunner(region=REGION)\n",
+    "runner._evaluator_level_cache.update(EVALUATOR_LEVELS)\n",
+    "\n",
+    "print(\"OnDemandEvaluationDatasetRunner configured. Starting evaluation...\")\n",
+    "print(f\"  Scenarios : {len(dataset.scenarios)}\")\n",
+    "print(f\"  Evaluators: {len(config.evaluator_config.evaluator_ids)} \"\n",
+    "      f\"(5 built-in + 2 custom)\")\n",
+    "print(f\"  Delay     : {config.evaluation_delay_seconds}s (waiting for CloudWatch ingestion)\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "runner-run",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Evaluation complete: 5 completed, 0 failed out of 5 scenarios.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Run the evaluation.\n",
+    "# OnDemandEvaluationDatasetRunner will:\n",
+    "#   1. Invoke agent_invoker for each turn in each scenario\n",
+    "#   2. Wait evaluation_delay_seconds for CloudWatch ingestion\n",
+    "#   3. Submit spans to the evaluation service\n",
+    "#   4. Return aggregated results\n",
+    "\n",
+    "eval_result = runner.run(\n",
+    "    config=config,\n",
+    "    dataset=dataset,\n",
+    "    agent_invoker=agent_invoker,\n",
+    "    span_collector=span_collector,\n",
+    ")\n",
+    "\n",
+    "completed = sum(1 for sr in eval_result.scenario_results if sr.status == \"COMPLETED\")\n",
+    "failed = sum(1 for sr in eval_result.scenario_results if sr.status == \"FAILED\")\n",
+    "print(f\"\\nEvaluation complete: {completed} completed, {failed} failed out of {len(eval_result.scenario_results)} scenarios.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "runner-results-md",
+   "metadata": {},
+   "source": [
+    "### 6c. Inspect Results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "runner-results",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "### Scenario: `city-new-york`\n",
+       "\n",
+       "| Evaluator | Value | Label | Explanation |\n",
+       "|---|---|---|---|\n",
+       "| `Builtin.Correctness` | 1.0 | Correct | The agent response provides population and area figures for New York City that are close to the expected response but with some di |\n",
+       "| `Builtin.GoalSuccessRate` | 1.0 | Yes | The agent successfully called web_search with the topic 'New York population and land area', satisfying the first assertion. The a |\n",
+       "| `Builtin.TrajectoryExactOrderMatch` | 1.0 | Yes | Exact match: Actual trajectory ['web_search'] matches expected trajectory ['web_search'] |\n",
+       "| `Builtin.TrajectoryInOrderMatch` | 1.0 | Yes | In-order match: All expected tools ['web_search'] found in order within actual ['web_search'] |\n",
+       "| `Builtin.TrajectoryAnyOrderMatch` | 1.0 | Yes | Any-order match: All expected tools ['web_search'] found in actual ['web_search'] |\n",
+       "| `CityResponseSimilarity_97db3e15-qX3R8q44` | 1.0 | highly_similar | The agent's response mentions a population of approximately 8.8 million and a land area of 302.6 square miles, which is slightly h |\n",
+       "| `CityAssertionChecker_97db3e15-aILiOJ37l4` | 1.0 | passed | The agent followed the expected tool trajectory by using the 'web_search' tool. It also satisfied all assertions by reporting a po |"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### Scenario: `city-los-angeles`\n",
+       "\n",
+       "| Evaluator | Value | Label | Explanation |\n",
+       "|---|---|---|---|\n",
+       "| `Builtin.Correctness` | 0.0 | Incorrect | The agent response provides significantly different factual information compared to the expected response. For population, the age |\n",
+       "| `Builtin.GoalSuccessRate` | 0.0 | No | The agent successfully called web_search to look up Los Angeles data. The agent reported a population of 3,902,440, which is close |\n",
+       "| `Builtin.TrajectoryExactOrderMatch` | 1.0 | Yes | Exact match: Actual trajectory ['web_search'] matches expected trajectory ['web_search'] |\n",
+       "| `Builtin.TrajectoryInOrderMatch` | 1.0 | Yes | In-order match: All expected tools ['web_search'] found in order within actual ['web_search'] |\n",
+       "| `Builtin.TrajectoryAnyOrderMatch` | 1.0 | Yes | Any-order match: All expected tools ['web_search'] found in actual ['web_search'] |\n",
+       "| `CityResponseSimilarity_97db3e15-qX3R8q44` | 0.5 | partially_similar | The agent's response provides a population of approximately 3,902,440 and a land area of 795.581 square miles. The expected respon |\n",
+       "| `CityAssertionChecker_97db3e15-aILiOJ37l4` | N/A | ERR:ValueError | No score found in evaluation result |"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### Scenario: `city-houston`\n",
+       "\n",
+       "| Evaluator | Value | Label | Explanation |\n",
+       "|---|---|---|---|\n",
+       "| `Builtin.Correctness` | 0.0 | Incorrect | The agent response provides significantly different factual information compared to the expected response. For population, the age |\n",
+       "| `Builtin.GoalSuccessRate` | 0.0 | No | The agent successfully called web_search to look up Houston data, satisfying the first assertion. However, the reported population |\n",
+       "| `Builtin.TrajectoryExactOrderMatch` | 1.0 | Yes | Exact match: Actual trajectory ['web_search'] matches expected trajectory ['web_search'] |\n",
+       "| `Builtin.TrajectoryInOrderMatch` | 1.0 | Yes | In-order match: All expected tools ['web_search'] found in order within actual ['web_search'] |\n",
+       "| `Builtin.TrajectoryAnyOrderMatch` | 1.0 | Yes | Any-order match: All expected tools ['web_search'] found in actual ['web_search'] |\n",
+       "| `CityResponseSimilarity_97db3e15-qX3R8q44` | 0.0 | not_similar | The agent's response has a population of 2,304,580, which is significantly different from the expected population of approximately |\n",
+       "| `CityAssertionChecker_97db3e15-aILiOJ37l4` | N/A | ERR:ValueError | No score found in evaluation result |"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### Scenario: `city-san-francisco`\n",
+       "\n",
+       "| Evaluator | Value | Label | Explanation |\n",
+       "|---|---|---|---|\n",
+       "| `Builtin.Correctness` | 1.0 | Correct | The agent response provides population and land area figures for San Francisco that are close to but slightly different from the e |\n",
+       "| `Builtin.GoalSuccessRate` | 1.0 | Yes | The agent successfully called web_search multiple times to look up San Francisco data, satisfying the first assertion. For the pop |\n",
+       "| `Builtin.TrajectoryExactOrderMatch` | 0.0 | No | Length mismatch: Expected 1 tools ['web_search'], but got 3 tools ['web_search', 'web_search', 'web_search'] |\n",
+       "| `Builtin.TrajectoryInOrderMatch` | 1.0 | Yes | In-order match: All expected tools ['web_search'] found in order within actual ['web_search', 'web_search', 'web_search'] |\n",
+       "| `Builtin.TrajectoryAnyOrderMatch` | 1.0 | Yes | Any-order match: All expected tools ['web_search'] found in actual ['web_search', 'web_search', 'web_search'] |\n",
+       "| `CityResponseSimilarity_97db3e15-qX3R8q44` | 0.0 | not_similar | The agent's response provides a population figure of 808,437 and a land area of 46.7 square miles, which are both lower than the e |\n",
+       "| `CityAssertionChecker_97db3e15-aILiOJ37l4` | 0.5 | partial | The agent executed the 'web_search' tool three times, which exceeds the expected trajectory of one 'web_search'. However, it is un |"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### Scenario: `city-comparison-multi`\n",
+       "\n",
+       "| Evaluator | Value | Label | Explanation |\n",
+       "|---|---|---|---|\n",
+       "| `Builtin.Correctness` | 1.0 | Correct | The agent response provides the core factual information requested: Seattle's population of 780,995 and land area of 83.84 square  |\n",
+       "| `Builtin.Correctness` | 0.0 | Incorrect | The agent response provides the population figure of 729,019 for Denver, CO, which matches the expected response exactly. However, |\n",
+       "| `Builtin.Correctness` | 1.0 | Correct | The agent response correctly identifies that Seattle has a higher population density than Denver, which matches the expected respo |\n",
+       "| `Builtin.GoalSuccessRate` | 1.0 | Yes | The agent successfully completed all three success assertions:  1. **Web search calls**: The agent called web_search multiple time |\n",
+       "| `Builtin.TrajectoryExactOrderMatch` | 0.0 | No | Length mismatch: Expected 2 tools ['web_search', 'web_search'], but got 6 tools ['web_search', 'web_search', 'web_search', 'web_se |\n",
+       "| `Builtin.TrajectoryInOrderMatch` | 1.0 | Yes | In-order match: All expected tools ['web_search', 'web_search'] found in order within actual ['web_search', 'web_search', 'web_sea |\n",
+       "| `Builtin.TrajectoryAnyOrderMatch` | 1.0 | Yes | Any-order match: All expected tools ['web_search', 'web_search'] found in actual ['web_search', 'web_search', 'web_search', 'web_s |\n",
+       "| `CityResponseSimilarity_97db3e15-qX3R8q44` | 1.0 | highly_similar | The agent's response matches the expected response closely. Both the population and land area figures are accurate and consistent  |\n",
+       "| `CityResponseSimilarity_97db3e15-qX3R8q44` | 0.5 | partially_similar | The agent's response provides a population number of approximately 729,019, which closely matches the expected response. However,  |\n",
+       "| `CityResponseSimilarity_97db3e15-qX3R8q44` | 1.0 | highly_similar | The agent's response includes the exact population and area figures for both Seattle and Denver, and provides the correct calculat |\n",
+       "| `CityAssertionChecker_97db3e15-aILiOJ37l4` | 0.5 | partial | The agent followed an unexpected tool trajectory by using 'web_search' six times instead of the expected two. Although the agent m |"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "def display_runner_results(eval_result) -> None:\n",
+    "    \"\"\"Display OnDemandEvaluationDatasetRunner results as a markdown table per scenario.\"\"\"\n",
+    "    for sr in eval_result.scenario_results:\n",
+    "        if sr.status == \"FAILED\":\n",
+    "            display(Markdown(f\"**Scenario `{sr.scenario_id}`** — FAILED: {sr.error}\"))\n",
+    "            continue\n",
+    "\n",
+    "        rows = [\"| Evaluator | Value | Label | Explanation |\",\n",
+    "                \"|---|---|---|---|\"]\n",
+    "        for er in sr.evaluator_results:\n",
+    "            for res in er.results:\n",
+    "                value = str(res.get(\"value\", res.get(\"score\", \"N/A\")))\n",
+    "                lbl = str(res.get(\"label\", res.get(\"rating\", \"\")))\n",
+    "                explanation = (res.get(\"explanation\", \"\") or \"\")[:130].replace(\"\\n\", \" \")\n",
+    "                error_code = res.get(\"errorCode\")\n",
+    "                if error_code:\n",
+    "                    lbl = f\"ERR:{error_code}\"\n",
+    "                    explanation = (res.get(\"errorMessage\", \"\") or \"\")[:130]\n",
+    "                rows.append(f\"| `{er.evaluator_id[:40]}` | {value} | {lbl} | {explanation} |\")\n",
+    "\n",
+    "        md = f\"### Scenario: `{sr.scenario_id}`\\n\\n\" + \"\\n\".join(rows)\n",
+    "        display(Markdown(md))\n",
+    "\n",
+    "\n",
+    "display_runner_results(eval_result)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "runner-summary",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Evaluator Summary (average score across all scenarios)\n",
+      "============================================================\n",
+      "  Builtin.Correctness                           avg=0.57  (n=7)\n",
+      "  Builtin.GoalSuccessRate                       avg=0.60  (n=5)\n",
+      "  Builtin.TrajectoryAnyOrderMatch               avg=1.00  (n=5)\n",
+      "  Builtin.TrajectoryExactOrderMatch             avg=0.60  (n=5)\n",
+      "  Builtin.TrajectoryInOrderMatch                avg=1.00  (n=5)\n",
+      "  CityAssertionChecker_97db3e15-aILiOJ37l4      avg=0.67  (n=3)\n",
+      "  CityResponseSimilarity_97db3e15-qX3R8q44BV    avg=0.57  (n=7)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Aggregate summary: average score per evaluator across all scenarios\n",
+    "from collections import defaultdict\n",
+    "\n",
+    "scores_by_evaluator = defaultdict(list)\n",
+    "for sr in eval_result.scenario_results:\n",
+    "    if sr.status != \"COMPLETED\":\n",
+    "        continue\n",
+    "    for er in sr.evaluator_results:\n",
+    "        for res in er.results:\n",
+    "            if \"value\" in res and res[\"value\"] is not None and not res.get(\"errorCode\"):\n",
+    "                scores_by_evaluator[er.evaluator_id].append(float(res[\"value\"]))\n",
+    "\n",
+    "print(\"\\nEvaluator Summary (average score across all scenarios)\")\n",
+    "print(\"=\" * 60)\n",
+    "for evaluator_id, scores in sorted(scores_by_evaluator.items()):\n",
+    "    avg = sum(scores) / len(scores)\n",
+    "    print(f\"  {evaluator_id:<45} avg={avg:.2f}  (n={len(scores)})\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "save-results-md",
+   "metadata": {},
+   "source": [
+    "### 6d. Save Results to File"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "save-results",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Results saved to: results/groundtruth_eval_20260415_195210.json\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/var/folders/7h/g0rdp4_96lvg7gd2h2b8c0d00000gq/T/ipykernel_32539/3226257259.py:5: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).\n",
+      "  timestamp = datetime.utcnow().strftime(\"%Y%m%d_%H%M%S\")\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "from datetime import datetime\n",
+    "\n",
+    "os.makedirs(\"results\", exist_ok=True)\n",
+    "timestamp = datetime.utcnow().strftime(\"%Y%m%d_%H%M%S\")\n",
+    "results_path = f\"results/groundtruth_eval_{timestamp}.json\"\n",
+    "\n",
+    "with open(results_path, \"w\") as f:\n",
+    "    json.dump(eval_result.model_dump(), f, indent=2, default=str)\n",
+    "\n",
+    "print(f\"Results saved to: {results_path}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cleanup-md",
+   "metadata": {},
+   "source": [
+    "## Step 7: Cleanup\n",
+    "\n",
+    "Delete the agent runtime endpoint when you're done to avoid ongoing costs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cleanup",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Uncomment to delete the agent runtime\n",
+    "# agentcore_runtime.delete()\n",
+    "# print(\"Agent runtime deleted.\")\n",
+    "\n",
+    "print(\"Cleanup skipped. Uncomment the cell above to delete the agent runtime.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "next-steps-md",
+   "metadata": {},
+   "source": [
+    "## Key Takeaways\n",
+    "\n",
+    "| | EvaluationClient | OnDemandEvaluationDatasetRunner |\n",
+    "|---|---|---|\n",
+    "| **When to use** | You have existing sessions | You have a test dataset |\n",
+    "| **Best for** | Post-hoc analysis, debugging | Regression testing, CI/CD |\n",
+    "| **Input** | session_id | Dataset of scenarios |\n",
+    "\n",
+    "### Built-in evaluator reference\n",
+    "\n",
+    "| Evaluator | Level | Ground truth required |\n",
+    "|---|---|---|\n",
+    "| `Builtin.Correctness` | TRACE | `expected_response` |\n",
+    "| `Builtin.GoalSuccessRate` | SESSION | `assertions` |\n",
+    "| `Builtin.TrajectoryExactOrderMatch` | SESSION | `expected_trajectory` |\n",
+    "| `Builtin.TrajectoryInOrderMatch` | SESSION | `expected_trajectory` |\n",
+    "| `Builtin.TrajectoryAnyOrderMatch` | SESSION | `expected_trajectory` |\n",
+    "\n",
+    "\n",
+    "### Custom evaluator ground truth placeholders\n",
+    "\n",
+    "Custom (LLM-as-a-judge) evaluators reference ground truth via placeholders in their `instructions`.\n",
+    "\n",
+    "| Level | Placeholder | Filled from |\n",
+    "|---|---|---|\n",
+    "| TRACE | `{assistant_turn}` | Agent's actual response |\n",
+    "| TRACE | `{expected_response}` | `ReferenceInputs.expected_response` |\n",
+    "| TRACE | `{context}` | Session context |\n",
+    "| SESSION | `{actual_tool_trajectory}` | Tools called by the agent |\n",
+    "| SESSION | `{expected_tool_trajectory}` | `ReferenceInputs.expected_trajectory` |\n",
+    "| SESSION | `{assertions}` | `ReferenceInputs.assertions` |\n",
+    "| SESSION | `{available_tools}` | Tools available to the agent |"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/05-framework-specific-evaluations/05-04-AgentCore-Runtime-Evals/requirements.txt
+++ b/05-framework-specific-evaluations/05-04-AgentCore-Runtime-Evals/requirements.txt
@@ -1,9 +1,10 @@
-strands-agents
-strands-agents-tools
-bedrock-agentcore
-bedrock-agentcore-starter-toolkit
 ddgs
-boto3
 pandas
 requests
 beautifulsoup4
+bedrock-agentcore>=1.5.0
+bedrock-agentcore-starter-toolkit>=0.3.0
+boto3>=1.42.0
+strands-agents
+strands-agents-tools
+aws-opentelemetry-distro


### PR DESCRIPTION
Updates the AgentCore module (05-04) by adding a tutorial on ground truth evaluation using AgentCore Eval, a managed evaluation service released in early April 2026. This has been one of the most requested features from the community, and this addition closes the gap in our Agent Evaluation Workshop.

*Issue #, if available:*
Ground truth evaluation is widely regarded as the gold standard for evaluating AI agents. Previously, we relied on Strands Eval, which required developers to manage the infrastructure hosting the evaluation workload. Many customers raised this as a friction point. AgentCore Eval now offers a fully managed alternative, and we want to make it accessible through the workshop.

*Description of changes:*
Added a new notebook under 05-framework-specific-evaluations/05-04-AgentCore-Runtime-Evals. The notebook uses the same example agent from previous modules and demonstrates how to use AgentCore Eval for ground truth evaluation, providing a consistent and familiar learning experience.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
