### PR TITLE
Convert interactive tutor judges from Likert 1-5 to binary pass/fail

### DIFF
--- a/Interactive Learning/AGENTS.md
+++ b/Interactive Learning/AGENTS.md
@@ -55,7 +55,7 @@ Student: "I think faithfulness means the answer is correct"
 Tutor: "Close. If the answer is correct but uses info NOT in the retrieved context, is that faithful?"
 </good-example>
 
-<bad-example reason="WITHHOLD+ONE-THING">
+<bad-example reason="WITHHOLD+ONE-THING; also models a Likert 1-5 scale, which this workshop teaches learners to replace with binary pass/fail checks">
 Tutor: "The fix is a structured rubric. Here are 4 categories: [A,B,C,D]. Using a 1-5 scale, rate this."
 </bad-example>
 <good-example>

--- a/Interactive Learning/framework evals/SKILL-agentcore.md
+++ b/Interactive Learning/framework evals/SKILL-agentcore.md
@@ -152,7 +152,7 @@ def tool_selection_score(expected: list, actual: list) -> dict:
 
 ### Section 3: LLM-as-Judge Quality Evaluation
 
-**Concept:** For dimensions that can't be computed deterministically (helpfulness, accuracy, clarity), you use a stronger model as an evaluator. The pattern: construct a rubric prompt, send the agent's response to the judge model, parse structured scores. This gives you multi-dimensional quality metrics per invocation.
+**Concept:** For dimensions that can't be computed deterministically (helpfulness, accuracy, clarity), you use a stronger model as an evaluator. Ask the judge for a **binary pass/fail on each dimension** rather than a 1–5 score: scales drift between runs, invite middle-value hedging, and are harder to act on than "failed the *accuracy* check." Keep granularity by evaluating several specific checks independently, then report the **pass rate per check** across invocations.
 
 **Build:**
 
@@ -162,12 +162,18 @@ import boto3, json
 bedrock = boto3.client('bedrock-runtime')
 
 def evaluate_quality(query: str, response: str, model_id: str) -> dict:
-    prompt = f"""Evaluate this agent response on a 1-5 scale for each metric.
+    prompt = f"""Evaluate this agent response as a BINARY pass/fail on each metric.
+A metric PASSES only if it fully meets the criterion — when in doubt, fail it.
 Query: {query}
 Response: {response}
 
-Metrics: HELPFULNESS, ACCURACY, CLARITY, COMPLETENESS
-Respond with ONLY a JSON object: {{"helpfulness": N, "accuracy": N, "clarity": N, "completeness": N}}"""
+- HELPFULNESS: PASS if the response actually addresses the user's request; FAIL otherwise.
+- ACCURACY: PASS if every factual claim is correct; FAIL if any is wrong or unsupported.
+- CLARITY: PASS if the response is clear and unambiguous; FAIL otherwise.
+- COMPLETENESS: PASS if it addresses all parts of the query; FAIL if any part is missing.
+
+Respond with ONLY a JSON object (each value a JSON boolean true/false):
+{{"helpfulness": <true|false>, "accuracy": <true|false>, "clarity": <true|false>, "completeness": <true|false>}}"""
 
     result = bedrock.invoke_model(
         modelId=model_id,
@@ -247,7 +253,7 @@ for tc in test_cases:
 # Aggregate
 import statistics
 print(f"Mean Tool F1: {statistics.mean(r['tool_f1'] for r in results):.2f}")
-print(f"Mean Accuracy: {statistics.mean(r['accuracy'] for r in results):.1f}/5")
+print(f"Accuracy pass rate: {statistics.mean(1 if r['accuracy'] else 0 for r in results):.0%}")
 ```
 
 ---

--- a/Interactive Learning/meta/validate_skills.sh
+++ b/Interactive Learning/meta/validate_skills.sh
@@ -47,6 +47,19 @@ while IFS= read -r -d '' f; do
     echo "  FAIL: Uses 'Success criteria' instead of 'Assessment criteria'"; ERRORS=$((ERRORS + 1))
   fi
 
+  # Likert-scale regression guard — the workshop teaches binary pass/fail, not 1-5 rating scales.
+  # Matches prescriptive scoring mechanics (rubric instructions, JSON score fields, X/5 output),
+  # NOT prose that mentions 1-5 as an anti-pattern (those use an en-dash "1–5").
+  # NOTE: SKILL-quality.md is a known pending exception (notebooks 02 vs 03 contradict; conversion
+  # awaiting a design decision) — it WARNs instead of failing until converted.
+  if grep -qiE 'score each.*1-[0-9]|"score":[[:space:]]*<?[0-9]-[0-9]|[[:space:]]X/[0-9]|scored 1-[0-9]|on a 1-[0-9] scale' "$f"; then
+    if [ "$(basename "$f")" = "SKILL-quality.md" ]; then
+      echo "  WARN: Likert 1-5 scoring present (SKILL-quality.md — conversion pending decision)"
+    else
+      echo "  FAIL: Likert 1-5 scoring detected — use binary pass/fail (see AGENTS.md)"; ERRORS=$((ERRORS + 1))
+    fi
+  fi
+
   # Non-standard section names
   if grep -q '^## What You Will Build\|^## What You Will Learn' "$f"; then
     echo "  FAIL: Non-standard section name (use '## Learning Objectives')"; ERRORS=$((ERRORS + 1))

--- a/Interactive Learning/workload evals/SKILL-multiagent-context.md
+++ b/Interactive Learning/workload evals/SKILL-multiagent-context.md
@@ -642,7 +642,7 @@ The dynamic swarm reveals a new evaluation dimension: **path divergence**. Run t
 | Memory Write Accuracy | Is what the agent wrote to memory factually correct? |
 | Redundant Context | How much repeated/irrelevant context was transferred? |
 
-Each metric is scored 1-5 by a judge LLM that sees the agent's input, retrieved context, and output.
+Each metric is a **binary pass/fail** judged by an LLM that sees the agent's input, retrieved context, and output. Binary verdicts avoid the boundary drift and middle-value hedging of 1–5 scales and give you a clear pass rate per metric; granularity comes from the six specific checks below, not from a graded score.
 
 **Build:** The `LLMJudge` class wraps Bedrock Converse calls with structured JSON output:
 
@@ -673,14 +673,15 @@ class LLMJudge:
     def judge_context_freshness(self, latest_user_msg: str, retrieved_context: str,
                                 agent_name: str) -> dict:
         if not retrieved_context.strip():
-            return {"score": 5, "reasoning": "No prior context (first call)"}
+            return {"passed": True, "reasoning": "No prior context (first call)"}
         prompt = f"""Evaluate whether the {agent_name} agent's retrieved context reflects
-the latest user requirements. Score 1-5 (5 = fully current, 1 = completely stale).
+the latest user requirements. Return a BINARY pass/fail — PASS only if the context is
+fully current; when in doubt, fail it.
 
 Latest user message: \"\"\"{latest_user_msg}\"\"\"
 Retrieved context: \"\"\"{retrieved_context[:3000]}\"\"\"
 
-Respond JSON only: {{"score": <1-5>, "reasoning": "<one sentence>",
+Respond JSON only: {{"passed": <true|false>, "reasoning": "<one sentence>",
 "stale_fields": ["list outdated fields"]}}"""
         return self._call(prompt)
 
@@ -692,8 +693,9 @@ Do agents agree on key facts (numbers, dates, constraints)?
 
 {agent_texts}
 
-Score 1-5 (5 = all agree, 1 = major contradictions).
-Respond JSON only: {{"score": <1-5>, "reasoning": "<one sentence>",
+Return a BINARY pass/fail — PASS only if agents agree on all key facts; FAIL if there is
+any genuine contradiction.
+Respond JSON only: {{"passed": <true|false>, "reasoning": "<one sentence>",
 "contradictions": ["list genuine contradictions"]}}"""
         return self._call(prompt)
 ```
@@ -731,15 +733,15 @@ feedback_metrics.evaluate_all()
 for turn in feedback_metrics.turns:
     print(f"\nTurn {turn.turn_number}:")
     for rec in turn.agent_calls:
-        freshness = rec.judge_scores.get("context_freshness", {}).get("score", "?")
-        print(f"  {rec.agent_name}: freshness={freshness}/5")
-    sc = turn.state_consistency.get("score", "?")
-    print(f"  State Consistency: {sc}/5")
+        fresh = rec.judge_scores.get("context_freshness", {}).get("passed", "?")
+        print(f"  {rec.agent_name}: freshness={'PASS' if fresh is True else 'FAIL' if fresh is False else '?'}")
+    sc = turn.state_consistency.get("passed", "?")
+    print(f"  State Consistency: {'PASS' if sc is True else 'FAIL' if sc is False else '?'}")
     for c in turn.state_consistency.get("contradictions", []):
         print(f"    ⚠️ {c}")
 ```
 
-**Interpreting results:** Context Freshness drops when an agent reads memory that doesn't reflect the latest user message. State Consistency drops when agents disagree on key facts. In the feedback session, expect lower scores on turn 2 — that's where the scope change tests whether peers reconcile or inherit stale context.
+**Interpreting results:** Context Freshness fails when an agent reads memory that doesn't reflect the latest user message. State Consistency fails when agents disagree on key facts. In the feedback session, expect failures on turn 2 — that's where the scope change tests whether peers reconcile or inherit stale context. Track the **pass rate per metric across turns** rather than an average score; "State Consistency fails on 2 of 5 turns" points straight at the turns to debug.
 
 ## Section 5: Conflict Detection and Comparative Analysis
 
@@ -785,14 +787,14 @@ def comparison_report(a: MetricsCollector, b: MetricsCollector,
     header = f"| Metric | {label_a} | {label_b} | Delta |"
     lines.extend([header, "|--------|----------|----------|-------|"])
 
-    def avg_score(collector, key):
-        scores = []
+    def pass_rate(collector, key):
+        flags = []
         for t in collector.turns:
             for r in t.agent_calls:
-                s = r.judge_scores.get(key, {}).get("score")
-                if s is not None:
-                    scores.append(s)
-        return sum(scores) / len(scores) if scores else 0
+                v = r.judge_scores.get(key, {}).get("passed")
+                if v is not None:
+                    flags.append(1 if v else 0)
+        return sum(flags) / len(flags) if flags else 0
 
     for key, label in [
         ("context_freshness", "Context Freshness"),
@@ -801,9 +803,9 @@ def comparison_report(a: MetricsCollector, b: MetricsCollector,
         ("write_accuracy", "Write Accuracy"),
         ("redundant_context", "Context Efficiency"),
     ]:
-        sa, sb = avg_score(a, key), avg_score(b, key)
+        sa, sb = pass_rate(a, key), pass_rate(b, key)
         d = sb - sa
-        lines.append(f"| {label} | {sa:.1f}/5 | {sb:.1f}/5 | {'+' if d>=0 else ''}{d:.1f} |")
+        lines.append(f"| {label} | {sa:.0%} | {sb:.0%} | {'+' if d>=0 else ''}{d:.0%} |")
 
     return "\n".join(lines)
 
@@ -818,7 +820,7 @@ import numpy as np
 
 
 def plot_context_metrics_radar(collector, session_label: str):
-    """Radar chart of average LLM-judge scores."""
+    """Radar chart of per-metric LLM-judge pass rates."""
     metrics = ["context_freshness", "handoff_completeness", "context_utilization",
                "write_accuracy", "redundant_context"]
     labels = ["Freshness", "Handoff", "Ctx Util", "Write Acc", "Low Redund"]
@@ -828,9 +830,9 @@ def plot_context_metrics_radar(collector, session_label: str):
         vals = []
         for t in collector.turns:
             for r in t.agent_calls:
-                s = r.judge_scores.get(key, {}).get("score")
-                if s is not None:
-                    vals.append(s)
+                v = r.judge_scores.get(key, {}).get("passed")
+                if v is not None:
+                    vals.append(1 if v else 0)
         scores.append(sum(vals) / len(vals) if vals else 0)
 
     N = len(labels)
@@ -843,8 +845,8 @@ def plot_context_metrics_radar(collector, session_label: str):
     ax.plot(angles, scores_plot, "o-", linewidth=2, color="#2196F3")
     ax.set_xticks(angles[:-1])
     ax.set_xticklabels(labels)
-    ax.set_ylim(0, 5)
-    ax.set_title(f"Context Quality — {session_label}", pad=20)
+    ax.set_ylim(0, 1)
+    ax.set_title(f"Context Quality (pass rate) — {session_label}", pad=20)
     plt.tight_layout()
     return fig
 
@@ -855,9 +857,9 @@ plt.show()
 ```
 
 **Key takeaways from conflict detection:**
-- Context Freshness < 3 means agents are working with stale information
-- State Consistency < 3 means agents disagree on key facts
-- The delta between baseline and conflict sessions quantifies your system's resilience to mid-session changes
+- A low Context Freshness pass rate means agents are working with stale information
+- A low State Consistency pass rate means agents disagree on key facts
+- The delta in pass rates between baseline and conflict sessions quantifies your system's resilience to mid-session changes
 - Production fix: version memory entries and re-dispatch affected agents after constraint updates
 
 ## Challenges
@@ -871,7 +873,7 @@ Design and instrument a multi-agent evaluation for a **customer support escalati
 3. **Instrument with MetricsCollector** — record handoffs, memory reads/writes, latency, and tokens for every agent call.
 4. **Introduce a mid-session constraint change** — e.g., the customer escalates from billing to technical, or changes their account type mid-conversation. This must test whether agents propagate the update.
 5. **Run baseline vs conflict sessions** and produce a comparison report showing metric deltas.
-6. **Interpret the results** — identify ≥2 specific coordination failures from the metrics (e.g., "the resolution agent used the old account type because Context Freshness dropped to 2/5 on turn 3").
+6. **Interpret the results** — identify ≥2 specific coordination failures from the metrics (e.g., "the resolution agent used the old account type because Context Freshness failed on turn 3").
 
 **Assessment criteria:**
 - Implements ≥1 architecture with ≥3 agents that have distinct system prompts

--- a/Interactive Learning/workload evals/SKILL-tool-calling.md
+++ b/Interactive Learning/workload evals/SKILL-tool-calling.md
@@ -381,7 +381,7 @@ Mock tool evaluation tests the model's live decisions — not just recorded beha
 
 ## Section 4: LLM-as-Judge for Tool Calling (Cost: $$)
 
-**Concept:** Programmatic metrics catch clear-cut errors, but some quality aspects require judgment: Was tool selection *appropriate* even if technically valid? Was the sequence *efficient*? Was the final response *helpful* given the tool results? An LLM judge evaluates these subjective dimensions using a structured rubric, scoring on 5 dimensions (tool selection, parameter quality, sequence logic, efficiency, response quality) on a 1–5 scale.
+**Concept:** Programmatic metrics catch clear-cut errors, but some quality aspects require judgment: Was tool selection *appropriate* even if technically valid? Was the sequence *efficient*? Was the final response *helpful* given the tool results? An LLM judge evaluates these subjective dimensions. Ask the judge for a **binary pass/fail on each dimension**, not a 1–5 score — Likert scales feel more informative but drift between runs (the line between a 3 and a 4 is subjective), let judges park uncertain cases in the middle, are harder to act on ("avg 3.8/5" vs "failed the *efficiency* check"), and need larger samples to compare. Keep granularity by **decomposing quality into 5 specific binary checks** (tool selection, parameter quality, sequence logic, efficiency, response quality), each with an explicit pass criterion; track the **pass rate across checks** plus an **all-checks-pass gate** for an overall verdict. (Reasoning follows [Hamel Husain's evals FAQ](https://hamel.dev/blog/posts/evals-faq/#q-why-do-you-recommend-binary-passfail-evaluations-instead-of-1-5-ratings-likert-scales).)
 
 **Build the judge:**
 
@@ -434,20 +434,22 @@ def judge_trajectory(test_case, result):
 {result['final_output'][:500]}
 </final_response>
 
-Evaluate on 5 dimensions (score each 1-5):
-1. **Tool Selection**: Right tools for the task?
-2. **Parameter Quality**: Correct, complete, well-formed?
-3. **Sequence Logic**: Sensible, efficient order?
-4. **Efficiency**: Minimum tools needed, no waste?
-5. **Response Quality**: Final response addresses the user's request?
+Evaluate each of these 5 dimensions as a BINARY pass/fail. A dimension PASSES only if it
+fully meets the criterion below — when in doubt, fail it. Do not hedge; every dimension must
+be either true (pass) or false (fail).
+1. **Tool Selection** — PASS if the agent called the right tools with no wrong or unnecessary tools; FAIL otherwise.
+2. **Parameter Quality** — PASS if every parameter is correct, complete, and well-formed; FAIL if any is hallucinated, missing, or malformed.
+3. **Sequence Logic** — PASS if tools were called in a sensible, logical order; FAIL if the ordering is illogical or would break the task.
+4. **Efficiency** — PASS if the agent used the minimum tools needed with no redundant calls; FAIL if there were wasteful or duplicate calls.
+5. **Response Quality** — PASS if the final response appropriately and helpfully addresses the user's request; FAIL otherwise.
 
-Return ONLY valid JSON:
+Return ONLY valid JSON (each "passed" must be a JSON boolean true/false):
 {{
-    "tool_selection": {{"score": <1-5>, "reason": "<brief>"}},
-    "parameter_quality": {{"score": <1-5>, "reason": "<brief>"}},
-    "sequence_logic": {{"score": <1-5>, "reason": "<brief>"}},
-    "efficiency": {{"score": <1-5>, "reason": "<brief>"}},
-    "response_quality": {{"score": <1-5>, "reason": "<brief>"}},
+    "tool_selection": {{"passed": <true|false>, "reason": "<brief>"}},
+    "parameter_quality": {{"passed": <true|false>, "reason": "<brief>"}},
+    "sequence_logic": {{"passed": <true|false>, "reason": "<brief>"}},
+    "efficiency": {{"passed": <true|false>, "reason": "<brief>"}},
+    "response_quality": {{"passed": <true|false>, "reason": "<brief>"}},
     "overall_assessment": "<one sentence>"
 }}"""
 
@@ -468,18 +470,22 @@ judge_test_ids = ["tc-001", "tc-002", "tc-004", "tc-005", "tc-008", "tc-009", "t
 for tc_id in judge_test_ids:
     tc = tc_lookup[tc_id]
     result = run_with_mock_tools(tc['input'])
-    scores = judge_trajectory(tc, result)
+    verdicts = judge_trajectory(tc, result)
 
-    if 'error' not in scores:
-        dims = ['tool_selection', 'parameter_quality', 'sequence_logic', 'efficiency', 'response_quality']
-        avg_score = sum(scores[d]['score'] for d in dims) / len(dims)
+    if 'error' not in verdicts:
+        checks = ['tool_selection', 'parameter_quality', 'sequence_logic', 'efficiency', 'response_quality']
+        passed_flags = {c: bool(verdicts[c]['passed']) for c in checks}
+        num_passed = sum(passed_flags.values())
+        pass_rate = num_passed / len(checks)
+        overall_pass = all(passed_flags.values())  # all-checks-pass gate
         print(f"\n  {tc_id} - {tc['name']}")
-        for dim in dims:
-            print(f"    {dim:20s}: {scores[dim]['score']}/5 - {scores[dim]['reason']}")
-        print(f"    Average: {avg_score:.1f}/5")
+        for c in checks:
+            print(f"    {c:20s}: {'PASS' if passed_flags[c] else 'FAIL'} - {verdicts[c]['reason']}")
+        print(f"    Checks passed: {num_passed}/{len(checks)} ({pass_rate:.0%})")
+        print(f"    Overall: {'PASS' if overall_pass else 'FAIL'} (all checks must pass)")
 ```
 
-The LLM judge catches issues programmatic metrics miss: an agent that calls `lookup_order` before `initiate_return` gets a higher sequence logic score (good practice) even though both orderings produce correct F1. It also flags when a technically-correct response is unhelpful or confusing to the user.
+The LLM judge catches issues programmatic metrics miss: an agent that calls `lookup_order` before `initiate_return` passes the sequence-logic check (good practice) even though both orderings produce correct F1. It also fails a technically-correct response that is unhelpful or confusing to the user. Report the per-check pass rate across cases plus the all-checks-pass rate — both are directly actionable ("efficiency fails 40% of the time") in a way an average score never is.
 
 ## Section 5: Multi-Turn and Synthetic Simulation (Cost: $$$ – $$$$)
 


### PR DESCRIPTION
- SKILL-tool-calling.md: mirror merged notebook's binary judge (passed:true/false, all-checks-pass gate, per-check pass-rate reporting)
- SKILL-agentcore.md: binary per-metric judge + accuracy pass-rate aggregation
- SKILL-multiagent-context.md: binary judges, pass-rate comparison report + radar
- AGENTS.md: flag the 1-5 scale in the bad-example as the anti-pattern
- validate_skills.sh: guard against reintroducing Likert scoring (quality.md exempt, pending)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
